### PR TITLE
Remove login@telegram.org from banned.md

### DIFF
--- a/src/banned.md
+++ b/src/banned.md
@@ -23,7 +23,6 @@ head:
 
 - login@stel.com
 - recover@telegram.org
-- login@telegram.org
 - abuse@telegram.org
 
 邮件标题：


### PR DESCRIPTION
There is no publicly available evidence to substantiate that login@telegram.org is a valid email address for appeals; thereby, it should be removed.